### PR TITLE
Using postgresql 9.6 image in template-prod1

### DIFF
--- a/monolith/src/main/openshift/template-prod1.json
+++ b/monolith/src/main/openshift/template-prod1.json
@@ -452,7 +452,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "postgresql:9.5"
+                            "name": "postgresql:9.6"
                         }
                     }
                 },


### PR DESCRIPTION
Update to use the postgresql 9.6 image since that image stream is already there.